### PR TITLE
Update config file location to home directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-config.json
 ruwnch.cache.json
 .vscode
 .git

--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ This behaviour can be changed in config to stop the execution if an error occurs
 
 ## Config
 
-There are few options that can be changed in ruwnch runtime. These are done using the config.json provided.
-
-> config.json has to be in the same directory as ruwnch
+There are few options that can be changed in ruwnch runtime. These are done using the `.ruwnch.config` file in the home directory.
 
 ```json
 {

--- a/ruwnch.py
+++ b/ruwnch.py
@@ -1,4 +1,3 @@
-
 import sys
 import json
 import os
@@ -41,10 +40,13 @@ def get_config(key: str) -> bool | int | None:
         bool | int: value of the config
     """
 
-    if not os.path.exists("config.json"):
+    home_dir = os.path.expanduser("~")
+    config_path = os.path.join(home_dir, ".ruwnch.config")
+
+    if not os.path.exists(config_path):
         fatal("Config missing, this shouldn't be.")
 
-    with open("config.json", "r") as f:
+    with open(config_path, "r") as f:
         config = json.loads(f.read())
 
         try:
@@ -148,8 +150,11 @@ def fatal(msg: str):
 
 def generate_missing_files():
 
-    if not os.path.exists("config.json"):
-        with open("config.json", "w") as f:
+    home_dir = os.path.expanduser("~")
+    config_path = os.path.join(home_dir, ".ruwnch.config")
+
+    if not os.path.exists(config_path):
+        with open(config_path, "w") as f:
             json_string = json.dumps(DEFAULT_CONFIG)
             f.write(json_string)
 


### PR DESCRIPTION
Modify the configuration file location to be a dot file in the home directory called `.ruwnch.config`.

* **`ruwnch.py`**
  - Update `get_config` function to check for `.ruwnch.config` in the home directory.
  - Update `generate_missing_files` function to create `.ruwnch.config` in the home directory if it doesn't exist.
  - Update `get_config` function to use `.ruwnch.config` instead of `config.json`.

* **`README.md`**
  - Update the Config section to reflect the new location of the config file in the home directory.

